### PR TITLE
starthawaii: do not suppress qdbus error messages

### DIFF
--- a/scripts/starthawaii.in
+++ b/scripts/starthawaii.in
@@ -110,7 +110,7 @@ if [ -z "$DBUS_SESSION_BUS_ADDRESS" ] && type dbus-launch >/dev/null; then
 fi
 
 # Check whether D-Bus is OK
-if ! qdbus >/dev/null 2>/dev/null; then
+if ! qdbus >/dev/null; then
     echo "Could not start D-Bus session bus" 1>&2
     exit 1
 fi


### PR DESCRIPTION
With stdout suppressed, qdbus does not print anything to stderr in the
good case. And in the bad case, we do want to see the error output.
