### PR TITLE
CMakeLists.txt: enable c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ include(CPack)
 add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
 
 # Build flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -Wno-unused-parameter -std=c++0x")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -Wno-unused-parameter -std=c++11")
 
 # Assume release build by default
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
otherwise we se many errors like:

| git/src/compositor/shell.h:66:10: error: 'void Shell::shell_bind_resource(QtWaylandServer::hawaii_shell::Resource*)' marked override, but does not override
     void shell_bind_resource(Resource *resource) Q_DECL_OVERRIDE;

Signed-off-by: Andreas Müller schnitzeltony@googlemail.com
