### PR TITLE
Fixed compile against latest greenisland

### DIFF
--- a/compositor/main.cpp
+++ b/compositor/main.cpp
@@ -30,7 +30,7 @@
 #include <QtCore/QStandardPaths>
 #include <QtWidgets/QApplication>
 
-#include <Hawaii/greenisland_version.h>
+#include <Hawaii/GreenIsland/greenisland_version.h>
 #include <Hawaii/GSettings/QGSettings>
 
 #include "application.h"


### PR DESCRIPTION
Ran into this while trying to install hawaii-meta-git and its dependencies using yaourt on Arch Linux.